### PR TITLE
Update requestCreator.py

### DIFF
--- a/cjapy/requestCreator.py
+++ b/cjapy/requestCreator.py
@@ -24,6 +24,14 @@ class RequestCreator:
         },
         "statistics": {"functions": ["col-max", "col-min"]},
         "dataId": "",
+        "capacityMetadata":{
+            "associations": [
+                {
+                    "name": "applicationName",
+                    "value": "cjapy Python Library"
+                }
+            ]
+        }
     }
 
     def __init__(self, request: dict = None) -> None:


### PR DESCRIPTION
Adding metadata for internal tracking purposes - allows customers to see how many reports are coming from this library, and allows Adobe to see this as well.